### PR TITLE
Avoid PHP warning about deprecated use of class name as constructor

### DIFF
--- a/plugins/fckphplist.php
+++ b/plugins/fckphplist.php
@@ -52,8 +52,8 @@ class fckphplist extends phplistPlugin {
     ),
   );
 
-  function fckphplist() {
-    parent::phplistplugin();
+  function __construct() {
+    parent::__construct();
     $this->coderoot = dirname(__FILE__).'/fckphplist/';
   }
 


### PR DESCRIPTION
PHP 7.0.25 issues this warning

PHP Deprecated:  Methods with the same name as their class will not be constructors in a future version of PHP; fckphplist has a deprecated constructor in /home/duncan/www/lists_3.3.2-RC2/admin/plugins/fckphplist.php on line 11
